### PR TITLE
Add health controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/rest-api-core",
-  "version": "0.1.0-4",
+  "version": "0.1.0-5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/logion-network/logion-rest-api-core.git"

--- a/src/AuthenticationController.ts
+++ b/src/AuthenticationController.ts
@@ -21,7 +21,7 @@ import { AuthenticateRequestView, AuthenticateResponseView, RefreshRequestView, 
 import { Log } from './Logging';
 const { logger } = Log;
 
-export function fillInSpec(spec: OpenAPIV3.Document): void {
+export function fillInSpecForAuthenticationController(spec: OpenAPIV3.Document): void {
     const tagName = 'Authentication';
     addTag(spec, {
         name: tagName,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -2,7 +2,7 @@ import "./inversify.decorate";
 import { OpenAPIV3 } from 'express-oas-generator';
 import { Container } from 'inversify';
 import { schemas } from './ApiTypes';
-import { AuthenticationController, fillInSpec } from './AuthenticationController';
+import { AuthenticationController, fillInSpecForAuthenticationController } from './AuthenticationController';
 import { AuthenticationService } from './AuthenticationService';
 import { AuthenticationSystemFactory } from './AuthenticationSystemFactory';
 import { addSchema } from './OpenApi';
@@ -11,6 +11,7 @@ import { Dino } from "dinoloop";
 import { ApplicationErrorController } from "./ApplicationErrorController";
 import { JsonResponse } from "./JsonResponse";
 import { PolkadotService } from "./PolkadotService";
+import { fillInSpecForHealthController, HealthController } from "./HealthController";
 
 export function configureContainer(container: Container) {
     container.bind(SessionRepository).toSelf();
@@ -22,10 +23,12 @@ export function configureContainer(container: Container) {
 
     container.bind(ApplicationErrorController).toSelf().inTransientScope();
     container.bind(AuthenticationController).toSelf().inTransientScope();
+    container.bind(HealthController).toSelf().inTransientScope();
 }
 
 export function configureOpenApi(spec: OpenAPIV3.Document) {
-    fillInSpec(spec);
+    fillInSpecForAuthenticationController(spec);
+    fillInSpecForHealthController(spec);
 
     Object.keys(schemas).forEach(schemaName =>
         addSchema(spec, schemaName, schemas[schemaName]));
@@ -33,6 +36,7 @@ export function configureOpenApi(spec: OpenAPIV3.Document) {
 
 export function configureDinoloop(dino: Dino) {
     dino.registerController(AuthenticationController);
+    dino.registerController(HealthController);
     dino.registerApplicationError(ApplicationErrorController);
     dino.requestEnd(JsonResponse);
 }

--- a/src/HealthController.ts
+++ b/src/HealthController.ts
@@ -1,0 +1,51 @@
+import { injectable } from 'inversify';
+import { ApiController, Controller, Async, HttpGet } from 'dinoloop';
+import { OpenAPIV3 } from 'express-oas-generator';
+import { addTag, getDefaultResponses, setControllerTag } from './OpenApi';
+import { AuthenticationService } from './AuthenticationService';
+import { requireDefined } from './Assertions';
+
+export function fillInSpecForHealthController(spec: OpenAPIV3.Document): void {
+    const tagName = 'Health';
+    addTag(spec, {
+        name: tagName,
+        description: "Health checks"
+    });
+    setControllerTag(spec, /^\/api\/health.*/, tagName);
+
+    HealthController.healthCheck(spec);
+}
+
+export abstract class HealthService {
+
+    abstract checkHealth(): Promise<void>;
+}
+
+@injectable()
+@Controller('/health')
+export class HealthController extends ApiController {
+
+    constructor(
+        private authenticationService: AuthenticationService,
+        private healthService: HealthService,
+    ) {
+        super();
+        this.healthCheckToken = process.env.HEALTH_TOKEN;
+    }
+
+    private readonly healthCheckToken: string | undefined;
+
+    static healthCheck(spec: OpenAPIV3.Document) {
+        const operationObject = requireDefined(spec.paths["/api/health"].get);
+        operationObject.summary = "Tells the status of the backend";
+        operationObject.description = "The request is authenticated with a token";
+        operationObject.responses = getDefaultResponses();
+    }
+
+    @HttpGet('')
+    @Async()
+    async healthCheck() {
+        this.authenticationService.ensureAuthorizationBearer(this.request, this.healthCheckToken);
+        await this.healthService.checkHealth();
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from "./AuthenticationSystemFactory";
 export * from "./Config";
 export * from "./DataSourceProvider";
 export * from "./Errors";
+export * from "./HealthController";
 export * from "./Logging";
 export * from "./LogionNamingStrategy";
 export * from "./OpenApi";

--- a/test/HealthController.spec.ts
+++ b/test/HealthController.spec.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import { Container } from "inversify";
+import { Mock } from "moq.ts";
+
+import { setupApp, mockAuthenticationWithCondition } from "../src/TestApp";
+import { HealthController, HealthService } from "../src/HealthController";
+
+describe('HealthController', () => {
+
+    beforeEach(() => {
+        process.env.HEALTH_TOKEN = EXPECTED_TOKEN;
+    })
+
+    it('OK when authenticated and up', async () => {
+        const app = setupApp(HealthController, container => bindMocks(container, true));
+
+        await request(app)
+            .get('/api/health')
+            .set('Authorization', `Bearer ${EXPECTED_TOKEN}`)
+            .expect(200);
+    });
+
+    it('Unauthorized', async () => {
+        const mock = mockAuthenticationWithCondition(false);
+        const app = setupApp(HealthController, container => bindMocks(container, true), mock);
+
+        await request(app)
+            .get('/api/health')
+            .set('Authorization', `Bearer ${UNEXPECTED_TOKEN}`)
+            .expect(401);
+    })
+
+    it('Internal when authenticated and down', async () => {
+        const app = setupApp(HealthController, container => bindMocks(container, false));
+
+        await request(app)
+            .get('/api/health')
+            .set('Authorization', `Bearer ${EXPECTED_TOKEN}`)
+            .expect(500);
+    })
+});
+
+const EXPECTED_TOKEN = "the-health-check-token";
+
+const UNEXPECTED_TOKEN = "wrong-health-check-token";
+
+function bindMocks(container: Container, up: boolean): void {
+    const healthService = new Mock<HealthService>();
+    if(up) {
+        healthService.setup(instance => instance.checkHealth()).returns(Promise.resolve());
+    } else {
+        healthService.setup(instance => instance.checkHealth).returns(() => Promise.reject(new Error()));
+    }
+    container.bind(HealthService).toConstantValue(healthService.object());
+}


### PR DESCRIPTION
* Health controller is shared by all REST API implementations
* The actual check is provided in the form of a `HealthService` subclass which will be injected