### PR TITLE
Fix TypeORM config

### DIFF
--- a/integration/Config.spec.ts
+++ b/integration/Config.spec.ts
@@ -1,0 +1,26 @@
+import { DataSource } from "typeorm";
+import { LogionNamingStrategy, SessionAggregateRoot, getEnvConfig } from "../src/index.js";
+
+describe("Config", () => {
+
+    it("no sync if requested", async () => {
+        process.env.TYPEORM_CONNECTION = "postgres";
+        process.env.TYPEORM_HOST = "localhost";
+        process.env.TYPEORM_USERNAME = "postgres";
+        process.env.TYPEORM_PASSWORD = "secret";
+        process.env.TYPEORM_DATABASE = "postgres";
+        process.env.TYPEORM_PORT = "5432";
+        process.env.TYPEORM_SYNCHRONIZE = "false";
+
+        const options = getEnvConfig();
+        options.namingStrategy = new LogionNamingStrategy();
+        options.entities = [ SessionAggregateRoot ];
+
+        const dataSource = new DataSource(options);
+        await dataSource.initialize();
+
+        const queryRunner = dataSource.createQueryRunner();
+        const tables = await queryRunner.getTables();
+        expect(tables.find(table => table.name === "session")).toBeUndefined();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/rest-api-core",
-  "version": "0.4.1",
+  "version": "0.4.2-1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/logion-network/logion-rest-api-core.git"

--- a/test/DataSourceProvider.spec.ts
+++ b/test/DataSourceProvider.spec.ts
@@ -1,0 +1,24 @@
+import { getEnvConfig, getFileConfig } from "../src/DataSourceProvider.js";
+
+describe("DataSourceProvider", () => {
+
+    it("reads options from env", () => {
+        process.env.TYPEORM_CONNECTION = "postgres";
+        process.env.TYPEORM_HOST = "localhost";
+        process.env.TYPEORM_USERNAME = "postgres";
+        process.env.TYPEORM_PASSWORD = "secret";
+        process.env.TYPEORM_DATABASE = "postgres";
+        process.env.TYPEORM_PORT = "5432";
+        process.env.TYPEORM_SYNCHRONIZE = "false";
+        process.env.TYPEORM_ENTITIES = "dist/model/*.model.js";
+        process.env.TYPEORM_MIGRATIONS = "dist/migration/*.js";
+
+        const options = getEnvConfig();
+        expect(options.synchronize).toBe(false);
+    });
+
+    it("reads options from file", () => {
+        const options = getFileConfig("test/ormconfig.json");
+        expect(options.synchronize).toBe(false);
+    });
+});

--- a/test/ormconfig.json
+++ b/test/ormconfig.json
@@ -1,0 +1,3 @@
+{
+  "synchronize": false
+}


### PR DESCRIPTION
* When read from environment, `synchronize` and `logging` are strings and interpreted as true if not falsy.
* This fix ensures that the variable has value "true" (the string) to be considered as true (the boolean).
* Without this, TypeORM was syncing the schema, even if the variable was equal to "false" (the string).
* Tests were added to prevent any regression on this.