### PR TITLE
`requireDefined` should not throw with falsy values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/rest-api-core",
-  "version": "0.4.3",
+  "version": "0.4.4-1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/logion-network/logion-rest-api-core.git"

--- a/src/Assertions.ts
+++ b/src/Assertions.ts
@@ -1,5 +1,5 @@
 export function requireDefined<T>(value: T | undefined | null, errorSupplier?: () => Error): T {
-    if(!value) {
+    if(value === undefined || value === null) {
         if (errorSupplier) {
             throw errorSupplier();
         } else {

--- a/test/Assertions.spec.ts
+++ b/test/Assertions.spec.ts
@@ -1,0 +1,19 @@
+import { requireDefined } from "../src/Assertions.js";
+
+describe("Assertions", () => {
+
+    describe("requireDefined", () => {
+
+        it("throws with null", () => {
+            expect(() => requireDefined(null)).toThrow();
+        });
+
+        it("throws with undefined", () => {
+            expect(() => requireDefined(undefined)).toThrow();
+        });
+
+        it("does not see 0 as null or undefined", () => {
+            expect(() => requireDefined(0)).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
* Currently, when passing `0` to `requireDefined`, an error is thrown, which should not be the case.
* Fixed code to stop relying on falsyness.